### PR TITLE
Add NSS 3.59.1 release notes

### DIFF
--- a/files/en-us/mozilla/projects/nss/nss_3.59.1_release_notes/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_3.59.1_release_notes/index.html
@@ -1,0 +1,32 @@
+---
+title: NSS 3.59.1 release notes
+slug: Mozilla/Projects/NSS/NSS_3.59.1_release_notes
+---
+<h2 id="Introduction">Introduction</h2>
+
+<p>The NSS team has released Network Security Services (NSS) 3.59.1 on <strong>18 December 2020</strong>, which is a patch release for NSS 3.59.</p>
+
+<h2 id="Distribution_Information">Distribution Information</h2>
+
+<p>The HG tag is NSS_3_59_1_RTM. NSS 3.59.1 requires NSPR 4.29 or newer.</p>
+
+<p>NSS 3.59.1 source distributions are available on ftp.mozilla.org for secure HTTPS download:</p>
+
+<ul>
+  <li>Source tarballs:<br>
+   <a href="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_59_1_RTM/src/">https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_59_1_RTM/src/</a></li>
+</ul>
+
+<h2 id="Bugs_fixed_in_NSS_3.59.1">Bugs fixed in NSS 3.59.1</h2>
+
+<ul>
+  <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1679290">Bug 1679290</a> - Fix potential deadlock with certain third-party PKCS11 modules.</li>
+</ul>
+
+<h2 id="Compatibility">Compatibility</h2>
+
+<p>NSS 3.59.1 shared libraries are backward compatible with all older NSS 3.x shared libraries. A program linked with older NSS 3.x shared libraries will work with NSS 3.59.1 shared libraries without recompiling or relinking. Furthermore, applications that restrict their use of NSS APIs to the functions listed in NSS Public Functions will remain compatible with future versions of the NSS shared libraries.</p>
+
+<h2 id="Feedback">Feedback</h2>
+
+<p>Bugs discovered should be reported by filing a bug report with<a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=NSS"> bugzilla.mozilla.org</a> (product NSS).</p>

--- a/files/en-us/mozilla/projects/nss/nss_3.59.1_release_notes/raw.html
+++ b/files/en-us/mozilla/projects/nss/nss_3.59.1_release_notes/raw.html
@@ -1,0 +1,30 @@
+<h2 id="Introduction">Introduction</h2>
+
+<p>The NSS team has released Network Security Services (NSS) 3.59.1 on <strong>18 December 2020</strong>, which is a patch release for NSS 3.59.</p>
+
+<h2 id="Distribution_Information">Distribution Information</h2>
+
+<p>The HG tag is NSS_3_59_1_RTM. NSS 3.59.1 requires NSPR 4.29 or newer.</p>
+
+<p>NSS 3.59.1 source distributions are available on ftp.mozilla.org for secure HTTPS download:</p>
+
+<ul>
+  <li>Source tarballs:<br>
+   <a href="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_59_1_RTM/src/">https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_59_1_RTM/src/</a></li>
+</ul>
+
+<p>Other releases are available <a href="/en-US/docs/Mozilla/Projects/NSS/NSS_Releases">in NSS Releases</a>.</p>
+
+<h2 id="Bugs_fixed_in_NSS_3.59.1">Bugs fixed in NSS 3.59.1</h2>
+
+<ul>
+ <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1679290">Bug 1679290</a> - Fix potential deadlock with certain third-party PKCS11 modules.</li>
+</ul>
+
+<h2 id="Compatibility">Compatibility</h2>
+
+<p>NSS 3.59.1 shared libraries are backward compatible with all older NSS 3.x shared libraries. A program linked with older NSS 3.x shared libraries will work with NSS 3.59.1 shared libraries without recompiling or relinking. Furthermore, applications that restrict their use of NSS APIs to the functions listed in NSS Public Functions will remain compatible with future versions of the NSS shared libraries.</p>
+
+<h2 id="Feedback">Feedback</h2>
+
+<p>Bugs discovered should be reported by filing a bug report with<a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=NSS"> bugzilla.mozilla.org</a> (product NSS).</p>

--- a/files/en-us/mozilla/projects/nss/nss_releases/raw.html
+++ b/files/en-us/mozilla/projects/nss/nss_releases/raw.html
@@ -5,6 +5,8 @@
 <h2 id="Past_releases">Past releases</h2>
 
 <ul>
+ <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_3.59.1_release_notes">NSS 3.59.1 release notes</a></li>
+ <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_3.60_release_notes">NSS 3.60 release notes</a></li>
  <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_3.59_release_notes">NSS 3.59 release notes</a></li>
  <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_3.58_release_notes">NSS 3.58 release notes</a></li>
  <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_3.57_release_notes">NSS 3.57 release notes</a></li>


### PR DESCRIPTION
Until https://github.com/mdn/content/issues/198 is resolved, NSS release notes exist in this repository. This PR adds release notes for NSS 3.59.1. 

Note: I've simply copied the format from the other versions. If anything else is needed when creating a new page, let me know.